### PR TITLE
Fix symbol warning on Linux plugin

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,6 +47,7 @@ chuck/src/core/util_thread.cpp \
 chuck/src/core/util_opsc.cpp \
 chuck/src/core/util_serial.cpp \
 chuck/src/core/util_hid.cpp \
+chuck/src/core/util_platforms.cpp \
 chuck/src/core/uana_xform.cpp \
 chuck/src/core/uana_extract.cpp
 


### PR DESCRIPTION
I built version 2.1.1 from source code, and opened the project from Unity, then the warning has shown.
```
Plugins: Couldn't open Assets/Chunity/Plugins/Linux/libAudioPluginChuck.so, error: Assets/Chunity/Plugins/Linux/libAudioPluginChuck.so: undefined symbol: _Z11ck_ttywidthv
```
And on the game startup, the library loading fails with exception.
This also happened at the latest code at main branch.

This change will fix the issue.
Regards,