### PR TITLE
updated NDK android version 24

### DIFF
--- a/src/Android/AndroidManifest.xml
+++ b/src/Android/AndroidManifest.xml
@@ -2,5 +2,5 @@
 package="chunity"
 android:versionCode="1"
 android:versionName="1.0">
-<uses-sdk android:minSdkVersion="21"/>
+<uses-sdk android:minSdkVersion="24"/>
 </manifest>

--- a/src/Android/jni/Android.mk
+++ b/src/Android/jni/Android.mk
@@ -16,7 +16,6 @@ LOCAL_SRC_FILES := ../../Plugin_ChucK.cpp \
 ../../chuck/src/core/chuck_frame.cpp \
 ../../chuck/src/core/chuck_symbol.cpp \
 ../../chuck/src/core/chuck_table.cpp \
-../../chuck/src/core/chuck_utils.cpp \
 ../../chuck/src/core/chuck_vm.cpp \
 ../../chuck/src/core/chuck_instr.cpp \
 ../../chuck/src/core/chuck_scan.cpp \

--- a/src/Android/jni/Application.mk
+++ b/src/Android/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_STL := c++_static
 APP_MODULES := AudioPluginChuck
-APP_PLATFORM := android-21
+APP_PLATFORM := android-24


### PR DESCRIPTION
Removed chuck_utils.cpp from Android.mk, chuck_utils no longer exists
Changed minimum android version from 21 to 24 in AndroidManifest.xml and Application.mk, otherwise apps are invalidated by Play Store

