### PR TITLE
Fix around WebGL global array get/sync APIs

### DIFF
--- a/Chunity Boilerplate/Assets/Chunity/Plugins/WebGL/AudioPluginChuck.jslib
+++ b/Chunity Boilerplate/Assets/Chunity/Plugins/WebGL/AudioPluginChuck.jslib
@@ -483,6 +483,26 @@ mergeInto(LibraryManager.library, {
         
         return true;
     },
+    startListeningForNamedChuckEvent: function( chuckID, name, callback )
+    {
+        (function( c, n ) {
+            var callbackID = theChuck.startListeningForEvent( UTF8ToString( name ), function() {
+                dynCall( 'vi', c, [n] );
+            });
+            this.stopIDs[ c ] = callbackID;
+        })(callback, name);
+        return true;
+    },
+    startListeningForChuckEventWithID: function( chuckID, callbackID, name, callback )
+    {
+        (function( c, i ) {
+            var listenerID = theChuck.startListeningForEvent( UTF8ToString( name ), function() {
+                dynCall( 'vi', c, [i] );
+            });
+            this.stopIDs[ c ] = listenerID;
+        })(callback, callbackID);
+        return true;
+    },
     startListeningForChuckEventWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         (function( g, m ) {
@@ -497,6 +517,16 @@ mergeInto(LibraryManager.library, {
         var callbackID = this.stopIDs[ callback ];
         return theChuck.stopListeningForEvent( Pointer_stringify( name ), callbackID );
     },
+    stopListeningForNamedChuckEvent: function( chuckID, name, callback )
+    {
+        var callbackID = this.stopIDs[ callback ];
+        return theChuck.stopListeningForEvent( UTF8ToString( name ), callbackID );
+    },
+    stopListeningForChuckEventWithID: function( chuckID, callbackID, name, callback )
+    {
+        var listenerID = this.stopIDs[ callback ];
+        return theChuck.stopListeningForEvent( UTF8ToString( name ), listenerID );
+    },
     stopListeningForChuckEventWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         var callbackID = this.stopIDs[ Pointer_stringify( gameObject ) + ":::" + Pointer_stringify( method ) ];
@@ -508,6 +538,12 @@ mergeInto(LibraryManager.library, {
     setGlobalIntArray: function( chuckID, name, arrayValues, numValues )
     {
         return theChuck.setIntArray( Pointer_stringify( name ), _cs32ArrayToJSArray( arrayValues, numValues ) );
+    },
+    // WebGL has no separate audio-thread path; alias to the regular setter
+    setGlobalIntArray_AT__deps: ['setGlobalIntArray'],
+    setGlobalIntArray_AT: function( chuckID, name, arrayValues, numValues )
+    {
+        return _setGlobalIntArray( chuckID, name, arrayValues, numValues );
     },
     getGlobalIntArray__deps: ['jsArrayToCS32Array'],
     getGlobalIntArray: function( chuckID, name, callback )
@@ -524,9 +560,50 @@ mergeInto(LibraryManager.library, {
             });
         })(callback);
     },
+    getNamedGlobalIntArray__deps: ['jsArrayToCS32Array'],
+    getNamedGlobalIntArray: function( chuckID, name, callback )
+    {
+        (function( c, n ) {
+            theChuck.getIntArray( n ).then( function( result ) {
+                var nameBufferSize = lengthBytesUTF8( n ) + 1;
+                var nameBuffer = _malloc( nameBufferSize );
+                stringToUTF8( n, nameBuffer, nameBufferSize );
+                var buffer = _malloc( 4 * result.length );
+                _jsArrayToCS32Array( result, buffer );
+                dynCall( 'vfii', c, [nameBuffer, buffer, result.length] );
+                _free( buffer );
+                _free( nameBuffer );
+            });
+        })(callback, UTF8ToString(name));
+    },
+    getGlobalIntArrayWithID__deps: ['jsArrayToCS32Array'],
+    getGlobalIntArrayWithID: function( chuckID, callbackID, name, callback )
+    {
+        (function( c, i ) {
+            theChuck.getIntArray( UTF8ToString( name ) ).then( function( result ) {
+                var buffer = _malloc( 4 * result.length );
+                _jsArrayToCS32Array( result, buffer );
+                dynCall( 'viii', c, [i, buffer, result.length] );
+                _free( buffer );
+            });
+        })(callback, callbackID);
+    },
+    getGlobalIntArrayWithUnityStyleCallback: function( chuckID, name, gameObject, method )
+    {
+        (function( g, m ) {
+            theChuck.getIntArray( UTF8ToString( name ) ).then( function( result ) {
+                unityInstance.SendMessage( g, m, JSON.stringify( { items: result } ) );
+            });
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
+    },
     setGlobalIntArrayValue: function( chuckID, name, index, value )
     {
         return theChuck.setIntArrayValue( Pointer_stringify( name ), index, value );
+    },
+    setGlobalIntArrayValue_AT__deps: ['setGlobalIntArrayValue'],
+    setGlobalIntArrayValue_AT: function( chuckID, name, index, value )
+    {
+        return _setGlobalIntArrayValue( chuckID, name, index, value );
     },
     getGlobalIntArrayValue: function( chuckID, name, index, callback )
     {
@@ -535,6 +612,26 @@ mergeInto(LibraryManager.library, {
                 dynCall( 'vi', c, [result] );
             });
         })(callback);
+    },
+    getNamedGlobalIntArrayValue: function( chuckID, name, index, callback )
+    {
+        (function( c, n ) {
+            theChuck.getIntArrayValue( n, index ).then( function( result ) {
+                var bufferSize = lengthBytesUTF8( n ) + 1;
+                var buffer = _malloc( bufferSize );
+                stringToUTF8( n, buffer, bufferSize );
+                dynCall( 'vfi', c, [buffer, result] );
+                _free( buffer );
+            });
+        })(callback, UTF8ToString(name));
+    },
+    getGlobalIntArrayValueWithID: function( chuckID, callbackID, name, index, callback )
+    {
+        (function( c, i ) {
+            theChuck.getIntArrayValue( UTF8ToString( name ), index ).then( function( result ) {
+                dynCall( 'vii', c, [i, result] );
+            });
+        })(callback, callbackID);
     },
     getGlobalIntArrayValueWithUnityStyleCallback: function( chuckID, name, index, gameObject, method )
     {
@@ -556,6 +653,26 @@ mergeInto(LibraryManager.library, {
             });
         })(callback);
     },
+    getNamedGlobalAssociativeIntArrayValue: function( chuckID, name, key, callback )
+    {
+        (function( c, n ) {
+            theChuck.getAssociativeIntArrayValue( n, UTF8ToString( key ) ).then( function( result ) {
+                var bufferSize = lengthBytesUTF8( n ) + 1;
+                var buffer = _malloc( bufferSize );
+                stringToUTF8( n, buffer, bufferSize );
+                dynCall( 'vfi', c, [buffer, result] );
+                _free( buffer );
+            });
+        })(callback, UTF8ToString(name));
+    },
+    getGlobalAssociativeIntArrayValueWithID: function( chuckID, callbackID, name, key, callback )
+    {
+        (function( c, i ) {
+            theChuck.getAssociativeIntArrayValue( UTF8ToString( name ), UTF8ToString( key ) ).then( function( result ) {
+                dynCall( 'vii', c, [i, result] );
+            });
+        })(callback, callbackID);
+    },
     getGlobalAssociativeIntArrayValueWithUnityStyleCallback: function( chuckID, name, key, gameObject, method )
     {
         (function( g, m ) {
@@ -571,6 +688,11 @@ mergeInto(LibraryManager.library, {
     {
         return theChuck.setFloatArray( Pointer_stringify( name ), _cs64FArrayToJSArray( arrayValues, numValues ) );
     },
+    setGlobalFloatArray_AT__deps: ['setGlobalFloatArray'],
+    setGlobalFloatArray_AT: function( chuckID, name, arrayValues, numValues )
+    {
+        return _setGlobalFloatArray( chuckID, name, arrayValues, numValues );
+    },
     getGlobalFloatArray__deps: ['jsArrayToCS64FArray'],
     getGlobalFloatArray: function( chuckID, name, callback )
     {
@@ -585,9 +707,50 @@ mergeInto(LibraryManager.library, {
             });
         })(callback);
     },
+    getNamedGlobalFloatArray__deps: ['jsArrayToCS64FArray'],
+    getNamedGlobalFloatArray: function( chuckID, name, callback )
+    {
+        (function( c, n ) {
+            theChuck.getFloatArray( n ).then( function( result ) {
+                var nameBufferSize = lengthBytesUTF8( n ) + 1;
+                var nameBuffer = _malloc( nameBufferSize );
+                stringToUTF8( n, nameBuffer, nameBufferSize );
+                var buffer = _malloc( 8 * result.length );
+                _jsArrayToCS64FArray( result, buffer );
+                dynCall( 'vfii', c, [nameBuffer, buffer, result.length] );
+                _free( buffer );
+                _free( nameBuffer );
+            });
+        })(callback, UTF8ToString(name));
+    },
+    getGlobalFloatArrayWithID__deps: ['jsArrayToCS64FArray'],
+    getGlobalFloatArrayWithID: function( chuckID, callbackID, name, callback )
+    {
+        (function( c, i ) {
+            theChuck.getFloatArray( UTF8ToString( name ) ).then( function( result ) {
+                var buffer = _malloc( 8 * result.length );
+                _jsArrayToCS64FArray( result, buffer );
+                dynCall( 'viii', c, [i, buffer, result.length] );
+                _free( buffer );
+            });
+        })(callback, callbackID);
+    },
+    getGlobalFloatArrayWithUnityStyleCallback: function( chuckID, name, gameObject, method )
+    {
+        (function( g, m ) {
+            theChuck.getFloatArray( UTF8ToString( name ) ).then( function( result ) {
+                unityInstance.SendMessage( g, m, JSON.stringify( { items: result } ) );
+            });
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
+    },
     setGlobalFloatArrayValue: function( chuckID, name, index, value )
     {
         return theChuck.setFloatArrayValue( Pointer_stringify( name ), index, value );
+    },
+    setGlobalFloatArrayValue_AT__deps: ['setGlobalFloatArrayValue'],
+    setGlobalFloatArrayValue_AT: function( chuckID, name, index, value )
+    {
+        return _setGlobalFloatArrayValue( chuckID, name, index, value );
     },
     getGlobalFloatArrayValue: function( chuckID, name, index, callback )
     {
@@ -596,6 +759,26 @@ mergeInto(LibraryManager.library, {
                 dynCall( 'vf', c, [result] );
             });
         })(callback);
+    },
+    getNamedGlobalFloatArrayValue: function( chuckID, name, index, callback )
+    {
+        (function( c, n ) {
+            theChuck.getFloatArrayValue( n, index ).then( function( result ) {
+                var bufferSize = lengthBytesUTF8( n ) + 1;
+                var buffer = _malloc( bufferSize );
+                stringToUTF8( n, buffer, bufferSize );
+                dynCall( 'vff', c, [buffer, result] );
+                _free( buffer );
+            });
+        })(callback, UTF8ToString(name));
+    },
+    getGlobalFloatArrayValueWithID: function( chuckID, callbackID, name, index, callback )
+    {
+        (function( c, i ) {
+            theChuck.getFloatArrayValue( UTF8ToString( name ), index ).then( function( result ) {
+                dynCall( 'vif', c, [i, result] );
+            });
+        })(callback, callbackID);
     },
     getGlobalFloatArrayValueWithUnityStyleCallback: function( chuckID, name, index, gameObject, method )
     {
@@ -616,6 +799,26 @@ mergeInto(LibraryManager.library, {
                 dynCall( 'vf', c, [result] );
             });
         })(callback);
+    },
+    getNamedGlobalAssociativeFloatArrayValue: function( chuckID, name, key, callback )
+    {
+        (function( c, n ) {
+            theChuck.getAssociativeFloatArrayValue( n, UTF8ToString( key ) ).then( function( result ) {
+                var bufferSize = lengthBytesUTF8( n ) + 1;
+                var buffer = _malloc( bufferSize );
+                stringToUTF8( n, buffer, bufferSize );
+                dynCall( 'vff', c, [buffer, result] );
+                _free( buffer );
+            });
+        })(callback, UTF8ToString(name));
+    },
+    getGlobalAssociativeFloatArrayValueWithID: function( chuckID, callbackID, name, key, callback )
+    {
+        (function( c, i ) {
+            theChuck.getAssociativeFloatArrayValue( UTF8ToString( name ), UTF8ToString( key ) ).then( function( result ) {
+                dynCall( 'vif', c, [i, result] );
+            });
+        })(callback, callbackID);
     },
     getGlobalAssociativeFloatArrayValueWithUnityStyleCallback: function( chuckID, name, key, gameObject, method )
     {

--- a/Chunity Boilerplate/Assets/Chunity/Plugins/WebGL/AudioPluginChuck.jslib
+++ b/Chunity Boilerplate/Assets/Chunity/Plugins/WebGL/AudioPluginChuck.jslib
@@ -68,7 +68,7 @@ mergeInto(LibraryManager.library, {
     initSubChuckInstance: function( chuckID, subChuckID, dacName )
     {
         var thisSubChuckReady = defer();
-        dacName = Pointer_stringify( dacName );
+        dacName = UTF8ToString( dacName );
         theChuck.runCode( "global Gain " + dacName + " => blackhole; true => " + dacName + ".buffered;" );
         this.subChucks[ subChuckID ] = createASubChuck( theChuck, dacName, thisSubChuckReady );
         this.subChucks[ subChuckID ].connect( audioContext.destination );
@@ -222,27 +222,27 @@ mergeInto(LibraryManager.library, {
     },
     runChuckCode: function( chuckID, code )
     {
-        return theChuck.runCode( Pointer_stringify( code ) );
+        return theChuck.runCode( UTF8ToString( code ) );
     },
     runChuckCodeWithReplacementDac: function( chuckID, code, replacementDac )
     {
-        return theChuck.runCodeWithReplacementDac( Pointer_stringify( code ), Pointer_stringify( replacementDac ) );
+        return theChuck.runCodeWithReplacementDac( UTF8ToString( code ), UTF8ToString( replacementDac ) );
     },
     runChuckFile: function( chuckID, filename ) 
     {
-        return theChuck.runFile( Pointer_stringify( filename ) );
+        return theChuck.runFile( UTF8ToString( filename ) );
     },
     runChuckFileWithReplacementDac: function( chuckID, filename, replacementDac )
     {
-        return theChuck.runFileWithReplacementDac( Pointer_stringify( filename ), Pointer_stringify( replacementDac ) );
+        return theChuck.runFileWithReplacementDac( UTF8ToString( filename ), UTF8ToString( replacementDac ) );
     },
     runChuckFileWithArgs: function( chuckID, filename, args )
     {
-        return theChuck.runFileWithArgs( Pointer_stringify( filename ), Pointer_stringify( args ) );
+        return theChuck.runFileWithArgs( UTF8ToString( filename ), UTF8ToString( args ) );
     },
     runChuckFileWithArgsWithReplacementDac: function( chuckID, filename, args, dacName )
     {
-        return theChuck.runFileWithArgsWithReplacementDac( Pointer_stringify( filename ), Pointer_stringify( args ), Pointer_stringify( dacName ) );
+        return theChuck.runFileWithArgsWithReplacementDac( UTF8ToString( filename ), UTF8ToString( args ), UTF8ToString( dacName ) );
     },
     setChoutCallback: function( chuckID, callback )
     {
@@ -271,12 +271,12 @@ mergeInto(LibraryManager.library, {
 
     setChuckInt: function( chuckID, name, val )
     {
-        return theChuck.setInt( Pointer_stringify( name ), val );
+        return theChuck.setInt( UTF8ToString( name ), val );
     },
     getChuckInt: function( chuckID, name, callback )
     {
         (function( c ) {
-            theChuck.getInt( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getInt( UTF8ToString( name ) ).then( function( result )
             {
                 dynCall( 'vi', c, [result] );
             });
@@ -296,12 +296,12 @@ mergeInto(LibraryManager.library, {
                 // be nice to memory
                 _free( buffer );
             });
-        })(callback, Pointer_stringify(name));
+        })(callback, UTF8ToString(name));
     },
     getChuckIntWithID: function( chuckID, callbackID, name, callback )
     {
         (function( c, i ) {
-            theChuck.getInt( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getInt( UTF8ToString( name ) ).then( function( result )
             {
                 dynCall( 'vii', c, [i, result] );
             });
@@ -310,20 +310,20 @@ mergeInto(LibraryManager.library, {
     getChuckIntWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getInt( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getInt( UTF8ToString( name ) ).then( function( result )
             {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     setChuckFloat: function( chuckID, name, val )
     {
-        return theChuck.setFloat( Pointer_stringify( name ), val );
+        return theChuck.setFloat( UTF8ToString( name ), val );
     },
     getChuckFloat: function( chuckID, name, callback )
     {
         (function( c ) {
-            theChuck.getFloat( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getFloat( UTF8ToString( name ) ).then( function( result )
             {
                 dynCall( 'vf', c, [result] );
             });
@@ -343,12 +343,12 @@ mergeInto(LibraryManager.library, {
                 // be nice to memory
                 _free( buffer );
             });
-        })(callback, Pointer_stringify(name)); 
+        })(callback, UTF8ToString(name)); 
     },
     getChuckFloatWithID: function( chuckID, callbackID, name, callback )
     {
         (function( c, i ) {
-            theChuck.getFloat( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getFloat( UTF8ToString( name ) ).then( function( result )
             {
                 dynCall( 'vif', c, [i, result] );
             });
@@ -357,20 +357,20 @@ mergeInto(LibraryManager.library, {
     getChuckFloatWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getFloat( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getFloat( UTF8ToString( name ) ).then( function( result )
             {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     setChuckString: function( chuckID, name, val )
     {
-        return theChuck.setString( Pointer_stringify( name ), Pointer_stringify( val ) );
+        return theChuck.setString( UTF8ToString( name ), UTF8ToString( val ) );
     },
     getChuckString: function( chuckID, name, callback )
     {
         (function( c ) {
-            theChuck.getString( Pointer_stringify( name ) ).then( function( result ) {
+            theChuck.getString( UTF8ToString( name ) ).then( function( result ) {
                 // need to turn JS result string into Module heap string.
                 var bufferSize = lengthBytesUTF8( result ) + 1;
                 var buffer = _malloc( bufferSize );
@@ -402,12 +402,12 @@ mergeInto(LibraryManager.library, {
                 _free( buffer );
                 _free( nameBuffer );
             });
-        })(callback, Pointer_stringify(name));
+        })(callback, UTF8ToString(name));
     },
     getChuckStringWithID: function( chuckID, callbackID, name, callback )
     {
         (function( c, i ) {
-            theChuck.getString( Pointer_stringify( name ) ).then( function( result ) {
+            theChuck.getString( UTF8ToString( name ) ).then( function( result ) {
                 // need to turn JS result string into Module heap string.
                 var bufferSize = lengthBytesUTF8( result ) + 1;
                 var buffer = _malloc( bufferSize );
@@ -422,24 +422,24 @@ mergeInto(LibraryManager.library, {
     getChuckStringWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getString( Pointer_stringify( name ) ).then( function( result )
+            theChuck.getString( UTF8ToString( name ) ).then( function( result )
             {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     signalChuckEvent: function( chuckID, name )
     {
-        return theChuck.signalEvent( Pointer_stringify( name ) );
+        return theChuck.signalEvent( UTF8ToString( name ) );
     },
     broadcastChuckEvent: function( chuckID, name )
     {
-        return theChuck.broadcastEvent( Pointer_stringify( name ) );
+        return theChuck.broadcastEvent( UTF8ToString( name ) );
     },
     listenForChuckEventOnce: function( chuckID, name, callback )
     {
         (function( c ) {
-            theChuck.listenForEventOnce( Pointer_stringify( name ), function() {
+            theChuck.listenForEventOnce( UTF8ToString( name ), function() {
                 dynCall( 'v', c, 0 );
             });
         })(callback);
@@ -448,7 +448,7 @@ mergeInto(LibraryManager.library, {
     listenForNamedChuckEventOnce: function( chuckID, name, callback )
     {
         (function( c, n ) {
-            theChuck.listenForEventOnce( Pointer_stringify( name ), function() {
+            theChuck.listenForEventOnce( UTF8ToString( name ), function() {
                 dynCall( 'vi', c, [n] );
             });
         })(callback, name);
@@ -457,7 +457,7 @@ mergeInto(LibraryManager.library, {
     listenForChuckEventOnceWithID: function( chuckID, callbackID, name, callback )
     {
         (function( c, i ) {
-            theChuck.listenForEventOnce( Pointer_stringify( name ), function() {
+            theChuck.listenForEventOnce( UTF8ToString( name ), function() {
                 dynCall( 'vi', c, [i] );
             });
         })(callback, callbackID);
@@ -466,16 +466,16 @@ mergeInto(LibraryManager.library, {
     listenForChuckEventOnceWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.listenForEventOnce( Pointer_stringify( name ), function()
+            theChuck.listenForEventOnce( UTF8ToString( name ), function()
             {
                 unityInstance.SendMessage( g, m );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     startListeningForChuckEvent: function( chuckID, name, callback )
     {
         (function( c ) {
-            var callbackID = theChuck.startListeningForEvent( Pointer_stringify( name ), function() {
+            var callbackID = theChuck.startListeningForEvent( UTF8ToString( name ), function() {
                 dynCall( 'v', c, 0 );
             });
             this.stopIDs[ c ] = callbackID;
@@ -506,16 +506,16 @@ mergeInto(LibraryManager.library, {
     startListeningForChuckEventWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
         (function( g, m ) {
-            var callbackID = theChuck.startListeningForEvent( Pointer_stringify( name ), function() {
+            var callbackID = theChuck.startListeningForEvent( UTF8ToString( name ), function() {
                 unityInstance.SendMessage( g, m );
             });
             this.stopIDs[ g + ":::" + m ] = callbackID;
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     stopListeningForChuckEvent: function( chuckID, name, callback )
     {
         var callbackID = this.stopIDs[ callback ];
-        return theChuck.stopListeningForEvent( Pointer_stringify( name ), callbackID );
+        return theChuck.stopListeningForEvent( UTF8ToString( name ), callbackID );
     },
     stopListeningForNamedChuckEvent: function( chuckID, name, callback )
     {
@@ -529,15 +529,15 @@ mergeInto(LibraryManager.library, {
     },
     stopListeningForChuckEventWithUnityStyleCallback: function( chuckID, name, gameObject, method )
     {
-        var callbackID = this.stopIDs[ Pointer_stringify( gameObject ) + ":::" + Pointer_stringify( method ) ];
-        theChuck.stopListeningForEvent( Pointer_stringify( name ), callbackID );
+        var callbackID = this.stopIDs[ UTF8ToString( gameObject ) + ":::" + UTF8ToString( method ) ];
+        theChuck.stopListeningForEvent( UTF8ToString( name ), callbackID );
     },
 
     // note: array is what Unity thinks is CKINT, which is 32 bit
     setGlobalIntArray__deps: ['cs32ArrayToJSArray'],
     setGlobalIntArray: function( chuckID, name, arrayValues, numValues )
     {
-        return theChuck.setIntArray( Pointer_stringify( name ), _cs32ArrayToJSArray( arrayValues, numValues ) );
+        return theChuck.setIntArray( UTF8ToString( name ), _cs32ArrayToJSArray( arrayValues, numValues ) );
     },
     // WebGL has no separate audio-thread path; alias to the regular setter
     setGlobalIntArray_AT__deps: ['setGlobalIntArray'],
@@ -549,7 +549,7 @@ mergeInto(LibraryManager.library, {
     getGlobalIntArray: function( chuckID, name, callback )
     {
         (function( c ) {
-            theChuck.getIntArray( Pointer_stringify( name ) ).then( function( result ) {
+            theChuck.getIntArray( UTF8ToString( name ) ).then( function( result ) {
                 console.log( "JS thinks the GET int array is ", result );
                 // need to malloc space for the array on the heap
                 // assuming 32 bit ints, since that's what unity thinks is an int size!
@@ -598,7 +598,7 @@ mergeInto(LibraryManager.library, {
     },
     setGlobalIntArrayValue: function( chuckID, name, index, value )
     {
-        return theChuck.setIntArrayValue( Pointer_stringify( name ), index, value );
+        return theChuck.setIntArrayValue( UTF8ToString( name ), index, value );
     },
     setGlobalIntArrayValue_AT__deps: ['setGlobalIntArrayValue'],
     setGlobalIntArrayValue_AT: function( chuckID, name, index, value )
@@ -608,7 +608,7 @@ mergeInto(LibraryManager.library, {
     getGlobalIntArrayValue: function( chuckID, name, index, callback )
     {
         (function( c ) {
-            theChuck.getIntArrayValue( Pointer_stringify( name ), index ).then( function( result ) {
+            theChuck.getIntArrayValue( UTF8ToString( name ), index ).then( function( result ) {
                 dynCall( 'vi', c, [result] );
             });
         })(callback);
@@ -636,19 +636,19 @@ mergeInto(LibraryManager.library, {
     getGlobalIntArrayValueWithUnityStyleCallback: function( chuckID, name, index, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getIntArrayValue( Pointer_stringify( name ), index ).then( function( result ) {
+            theChuck.getIntArrayValue( UTF8ToString( name ), index ).then( function( result ) {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     setGlobalAssociativeIntArrayValue: function( chuckID, name, key, value )
     {
-        return theChuck.setAssociativeIntArrayValue( Pointer_stringify( name ), Pointer_stringify( key ), value );
+        return theChuck.setAssociativeIntArrayValue( UTF8ToString( name ), UTF8ToString( key ), value );
     },
     getGlobalAssociativeIntArrayValue: function( chuckID, name, key, callback )
     {
         (function( c ) {
-            theChuck.getAssociativeIntArrayValue( Pointer_stringify( name ), Pointer_stringify( key ) ).then( function( result ) {
+            theChuck.getAssociativeIntArrayValue( UTF8ToString( name ), UTF8ToString( key ) ).then( function( result ) {
                 dynCall( 'vi', c, [result] );
             });
         })(callback);
@@ -676,17 +676,17 @@ mergeInto(LibraryManager.library, {
     getGlobalAssociativeIntArrayValueWithUnityStyleCallback: function( chuckID, name, key, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getAssociativeIntArrayValue( Pointer_stringify( name ), Pointer_stringify( key ) ).then( function( result ) {
+            theChuck.getAssociativeIntArrayValue( UTF8ToString( name ), UTF8ToString( key ) ).then( function( result ) {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
 
     // note: array is t_CKFLOAT == Float64 since that's what Unity thinks CKFLOAT is
     setGlobalFloatArray__deps: ['cs64FArrayToJSArray'],
     setGlobalFloatArray: function( chuckID, name, arrayValues, numValues )
     {
-        return theChuck.setFloatArray( Pointer_stringify( name ), _cs64FArrayToJSArray( arrayValues, numValues ) );
+        return theChuck.setFloatArray( UTF8ToString( name ), _cs64FArrayToJSArray( arrayValues, numValues ) );
     },
     setGlobalFloatArray_AT__deps: ['setGlobalFloatArray'],
     setGlobalFloatArray_AT: function( chuckID, name, arrayValues, numValues )
@@ -697,7 +697,7 @@ mergeInto(LibraryManager.library, {
     getGlobalFloatArray: function( chuckID, name, callback )
     {
         (function( c ) {
-            theChuck.getFloatArray( Pointer_stringify( name ) ).then( function( result ) {
+            theChuck.getFloatArray( UTF8ToString( name ) ).then( function( result ) {
                 // need to malloc space for the array on the heap
                 // assuming 64 bit floats, since that's what unity thinks is a float size!
                 var buffer = _malloc( 8 * result.length );
@@ -745,7 +745,7 @@ mergeInto(LibraryManager.library, {
     },
     setGlobalFloatArrayValue: function( chuckID, name, index, value )
     {
-        return theChuck.setFloatArrayValue( Pointer_stringify( name ), index, value );
+        return theChuck.setFloatArrayValue( UTF8ToString( name ), index, value );
     },
     setGlobalFloatArrayValue_AT__deps: ['setGlobalFloatArrayValue'],
     setGlobalFloatArrayValue_AT: function( chuckID, name, index, value )
@@ -755,7 +755,7 @@ mergeInto(LibraryManager.library, {
     getGlobalFloatArrayValue: function( chuckID, name, index, callback )
     {
         (function( c ) {
-            theChuck.getFloatArrayValue( Pointer_stringify( name ), index ).then( function( result ) {
+            theChuck.getFloatArrayValue( UTF8ToString( name ), index ).then( function( result ) {
                 dynCall( 'vf', c, [result] );
             });
         })(callback);
@@ -783,19 +783,19 @@ mergeInto(LibraryManager.library, {
     getGlobalFloatArrayValueWithUnityStyleCallback: function( chuckID, name, index, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getFloatArrayValue( Pointer_stringify( name ), index ).then( function( result ) {
+            theChuck.getFloatArrayValue( UTF8ToString( name ), index ).then( function( result ) {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     },
     setGlobalAssociativeFloatArrayValue: function( chuckID, name, key, value )
     {
-        return theChuck.setAssociativeFloatArrayValue( Pointer_stringify( name ), Pointer_stringify( key ), value );
+        return theChuck.setAssociativeFloatArrayValue( UTF8ToString( name ), UTF8ToString( key ), value );
     },
     getGlobalAssociativeFloatArrayValue: function( chuckID, name, key, callback )
     {
         (function( c ) {
-            theChuck.getAssociativeFloatArrayValue( Pointer_stringify( name ), Pointer_stringify( key ) ).then( function( result ) {
+            theChuck.getAssociativeFloatArrayValue( UTF8ToString( name ), UTF8ToString( key ) ).then( function( result ) {
                 dynCall( 'vf', c, [result] );
             });
         })(callback);
@@ -823,10 +823,10 @@ mergeInto(LibraryManager.library, {
     getGlobalAssociativeFloatArrayValueWithUnityStyleCallback: function( chuckID, name, key, gameObject, method )
     {
         (function( g, m ) {
-            theChuck.getAssociativeFloatArrayValue( Pointer_stringify( name ), Pointer_stringify( key ) ).then( function( result ) {
+            theChuck.getAssociativeFloatArrayValue( UTF8ToString( name ), UTF8ToString( key ) ).then( function( result ) {
                 unityInstance.SendMessage( g, m, result );
             });
-        })( Pointer_stringify( gameObject ), Pointer_stringify( method ) );
+        })( UTF8ToString( gameObject ), UTF8ToString( method ) );
     }
 
 

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Chuck.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Chuck.cs
@@ -1415,6 +1415,18 @@ public class Chuck
         return true;
     }
 
+    public bool GetIntArray( System.UInt32 chuckID, string variableName, string gameObjectWithCallback, string callback )
+    {
+        getGlobalIntArrayWithUnityStyleCallback( chuckID, variableName, gameObjectWithCallback, callback );
+        return true;
+    }
+
+    public bool GetFloatArray( System.UInt32 chuckID, string variableName, string gameObjectWithCallback, string callback )
+    {
+        getGlobalFloatArrayWithUnityStyleCallback( chuckID, variableName, gameObjectWithCallback, callback );
+        return true;
+    }
+
     public bool GetString( System.UInt32 chuckID, string variableName, string gameObjectWithCallback, string callback )
     {
         getChuckStringWithUnityStyleCallback( chuckID, variableName, gameObjectWithCallback, callback );
@@ -1481,9 +1493,13 @@ public class Chuck
     [DllImport( PLUGIN_NAME) ]
     private static extern void stopListeningForChuckEventWithUnityStyleCallback( System.UInt32 chuckID, System.String name, System.String gameObject, System.String method );
     [DllImport( PLUGIN_NAME) ]
+    private static extern void getGlobalIntArrayWithUnityStyleCallback( System.UInt32 chuckID, System.String name, System.String gameObject, System.String method );
+    [DllImport( PLUGIN_NAME) ]
     private static extern void getGlobalIntArrayValueWithUnityStyleCallback( System.UInt32 chuckID, System.String name, System.UInt32 index, System.String gameObject, System.String method );
     [DllImport( PLUGIN_NAME) ]
     private static extern void getGlobalAssociativeIntArrayValueWithUnityStyleCallback( System.UInt32 chuckID, System.String name, System.String key, System.String gameObject, System.String method );
+    [DllImport( PLUGIN_NAME) ]
+    private static extern void getGlobalFloatArrayWithUnityStyleCallback( System.UInt32 chuckID, System.String name, System.String gameObject, System.String method );
     [DllImport( PLUGIN_NAME) ]
     private static extern void getGlobalFloatArrayValueWithUnityStyleCallback( System.UInt32 chuckID, System.String name, System.UInt32 index, System.String gameObject, System.String method );
     [DllImport( PLUGIN_NAME) ]

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckMainInstance.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckMainInstance.cs
@@ -992,6 +992,16 @@ public class ChuckMainInstance : MonoBehaviour
         return Chuck.Manager.GetFloat( myChuckId, variableName, gameObjectWithCallback, callback );
     }
 
+    public bool GetIntArray( string variableName, string gameObjectWithCallback, string callback )
+    {
+        return Chuck.Manager.GetIntArray( myChuckId, variableName, gameObjectWithCallback, callback );
+    }
+
+    public bool GetFloatArray( string variableName, string gameObjectWithCallback, string callback )
+    {
+        return Chuck.Manager.GetFloatArray( myChuckId, variableName, gameObjectWithCallback, callback );
+    }
+
     public bool GetString( string variableName, string gameObjectWithCallback, string callback )
     {
         return Chuck.Manager.GetString( myChuckId, variableName, gameObjectWithCallback, callback );

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckSubInstance.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckSubInstance.cs
@@ -979,6 +979,16 @@ public class ChuckSubInstance : MonoBehaviour
         return chuckMainInstance.GetFloat( variableName, gameObjectWithCallback, callback );
     }
 
+    public bool GetIntArray( string variableName, string gameObjectWithCallback, string callback )
+    {
+        return chuckMainInstance.GetIntArray( variableName, gameObjectWithCallback, callback );
+    }
+
+    public bool GetFloatArray( string variableName, string gameObjectWithCallback, string callback )
+    {
+        return chuckMainInstance.GetFloatArray( variableName, gameObjectWithCallback, callback );
+    }
+
     public bool GetString( string variableName, string gameObjectWithCallback, string callback )
     {
         return chuckMainInstance.GetString( variableName, gameObjectWithCallback, callback );

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Examples/ChunityExampleGlobalFloatArray.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Examples/ChunityExampleGlobalFloatArray.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -50,8 +51,10 @@ public class ChunityExampleGlobalFloatArray : MonoBehaviour
 			}
 		" );
 
+		#if !UNITY_WEBGL
 		myFloatArrayCallback = GetInitialArrayCallback;
 		myFloatCallback = GetANumberCallback;
+		#endif
 	}
 
 	// Update is called once per frame
@@ -72,14 +75,13 @@ public class ChunityExampleGlobalFloatArray : MonoBehaviour
 
 
 			// test some gets too
-			myChuck.GetFloatArray( "myFloatNotes", myFloatArrayCallback );
 			#if UNITY_WEBGL
-			// WebGL specific float callback signature: game object name, method name
+			// WebGL: SendMessage can only pass string/number (arrays arrive as JSON)
+			myChuck.GetFloatArray( "myFloatNotes", gameObject.name, "GetInitialArrayCallback" );
 			myChuck.GetFloatArrayValue( "myFloatNotes", 1, gameObject.name, "GetANumberCallback" );
 			myChuck.GetAssociativeFloatArrayValue( "myFloatNotes", "numPlayed", gameObject.name, "GetANumberCallback" );
-		
-			// NOTE: can do it the below way if the callback is made into a *static* method
 			#else
+			myChuck.GetFloatArray( "myFloatNotes", myFloatArrayCallback );
 			myChuck.GetFloatArrayValue( "myFloatNotes", 1, myFloatCallback );
 			myChuck.GetAssociativeFloatArrayValue( "myFloatNotes", "numPlayed", myFloatCallback );
 			#endif
@@ -91,6 +93,30 @@ public class ChunityExampleGlobalFloatArray : MonoBehaviour
 		}
 	}
 
+#if UNITY_WEBGL
+	[Serializable]
+	private class FloatArrayJson
+	{
+		public CK_FLOAT[] items;
+	}
+
+	// Instance methods required for Unity SendMessage
+	void GetInitialArrayCallback( string json )
+	{
+		FloatArrayJson parsed = JsonUtility.FromJson<FloatArrayJson>( json );
+		CK_FLOAT[] values = ( parsed != null && parsed.items != null ) ? parsed.items : new CK_FLOAT[] {};
+		Debug.Log( "Float array has " + values.Length.ToString() + " numbers which are: " );
+		for( int i = 0; i < values.Length; i++ )
+		{
+			Debug.Log( "        " + values[i].ToString() );
+		}
+	}
+
+	void GetANumberCallback( float value )
+	{
+		Debug.Log( "I got a number! " + value.ToString() );
+	}
+#else
 	#if ( UNITY_IOS || UNITY_ANDROID ) && !UNITY_EDITOR
 	[AOT.MonoPInvokeCallback(typeof(Chuck.FloatArrayCallback))]
 	#endif
@@ -110,4 +136,5 @@ public class ChunityExampleGlobalFloatArray : MonoBehaviour
 	{
 		Debug.Log( "I got a number! " + value.ToString() );
 	}
+#endif
 }

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Examples/ChunityExampleGlobalIntArray.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Examples/ChunityExampleGlobalIntArray.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -50,8 +51,10 @@ public class ChunityExampleGlobalIntArray : MonoBehaviour
 			}
 		" );
 
+		#if !UNITY_WEBGL
 		myIntArrayCallback = GetInitialArrayCallback;
 		myIntCallback = GetANumberCallback;
+		#endif
 	}
 
 	// Update is called once per frame
@@ -74,15 +77,13 @@ public class ChunityExampleGlobalIntArray : MonoBehaviour
 
 
 			// test some gets too
-			myChuck.GetIntArray( "myNotes", myIntArrayCallback );
-
 			#if UNITY_WEBGL
-			// WebGL specific float callback signature: game object name, method name
+			// WebGL: SendMessage can only pass string/number (arrays arrive as JSON)
+			myChuck.GetIntArray( "myNotes", gameObject.name, "GetInitialArrayCallback" );
 			myChuck.GetIntArrayValue( "myNotes", 1, gameObject.name, "GetANumberCallback" );
 			myChuck.GetAssociativeIntArrayValue( "myNotes", "numPlayed", gameObject.name, "GetANumberCallback" );
-		
-			// NOTE: can do it the below way if the callback is made into a *static* method
 			#else
+			myChuck.GetIntArray( "myNotes", myIntArrayCallback );
 			myChuck.GetIntArrayValue( "myNotes", 1, myIntCallback );
 			myChuck.GetAssociativeIntArrayValue( "myNotes", "numPlayed", myIntCallback );
 			#endif
@@ -91,6 +92,30 @@ public class ChunityExampleGlobalIntArray : MonoBehaviour
 		}
 	}
 
+#if UNITY_WEBGL
+	[Serializable]
+	private class IntArrayJson
+	{
+		public CK_INT[] items;
+	}
+
+	// Instance methods required for Unity SendMessage
+	void GetInitialArrayCallback( string json )
+	{
+		IntArrayJson parsed = JsonUtility.FromJson<IntArrayJson>( json );
+		CK_INT[] values = ( parsed != null && parsed.items != null ) ? parsed.items : new CK_INT[] {};
+		Debug.Log( "Int array has " + values.Length.ToString() + " numbers which are: " );
+		for( int i = 0; i < values.Length; i++ )
+		{
+			Debug.Log( "        " + values[i].ToString() );
+		}
+	}
+
+	void GetANumberCallback( int value )
+	{
+		Debug.Log( "I got a number! " + value.ToString() );
+	}
+#else
 	#if ( UNITY_IOS || UNITY_ANDROID ) && !UNITY_EDITOR
 	[AOT.MonoPInvokeCallback(typeof(Chuck.IntArrayCallback))]
 	#endif
@@ -105,9 +130,10 @@ public class ChunityExampleGlobalIntArray : MonoBehaviour
 
 	#if ( UNITY_IOS || UNITY_ANDROID ) && !UNITY_EDITOR
 	[AOT.MonoPInvokeCallback(typeof(Chuck.IntCallback))]
-	#endif 
+	#endif
 	static void GetANumberCallback( CK_INT value )
 	{
 		Debug.Log( "I got a number! " + value.ToString() );
 	}
+#endif
 }

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Utility/ChuckFloatArraySyncer.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Utility/ChuckFloatArraySyncer.cs
@@ -146,17 +146,21 @@ public class ChuckFloatArraySyncer : MonoBehaviour
 
     private void AllocateCallback()
     {
+#if !UNITY_WEBGL
         // regular allocation
         myFloatArrayCallback = StaticCallback;
         activeCallbacks[myID] = this;
+#endif
     }
 
     private void ReturnCallback()
     {
+#if !UNITY_WEBGL
         // deallocate
         activeCallbacks.Remove( myID );
         // always set my callback to null
         myFloatArrayCallback = null;
+#endif
     }
 
 
@@ -178,16 +182,38 @@ public class ChuckFloatArraySyncer : MonoBehaviour
     }
 
     private CK_FLOAT[] myFloatArray = {};
+
+#if UNITY_WEBGL
+    [Serializable]
+    private class FloatArrayJson
+    {
+        public CK_FLOAT[] items;
+    }
+
+    private void MyCallback( string json )
+    {
+        if( string.IsNullOrEmpty( json ) )
+        {
+            myFloatArray = new CK_FLOAT[] {};
+            return;
+        }
+
+        FloatArrayJson parsed = JsonUtility.FromJson<FloatArrayJson>( json );
+        myFloatArray = ( parsed != null && parsed.items != null ) ? parsed.items : new CK_FLOAT[] {};
+    }
+#else
     private void MyCallback( CK_FLOAT[] newArray )
     {
         myFloatArray = newArray;
     }
+#endif
 
     void OnDestroy()
     {
         StopSyncing();
     }
 
+#if !UNITY_WEBGL
     #if AOT
     [AOT.MonoPInvokeCallback(typeof(Chuck.FloatArrayCallbackWithID))]
     #endif
@@ -198,5 +224,6 @@ public class ChuckFloatArraySyncer : MonoBehaviour
             activeCallbacks[id].MyCallback( newValue );
         }
     }
+#endif
     
 }

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Utility/ChuckIntArraySyncer.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Utility/ChuckIntArraySyncer.cs
@@ -146,17 +146,21 @@ public class ChuckIntArraySyncer : MonoBehaviour
 
     private void AllocateCallback()
     {
+#if !UNITY_WEBGL
         // regular allocation
         myIntArrayCallback = StaticCallback;
         activeCallbacks[myID] = this;
+#endif
     }
 
     private void ReturnCallback()
     {
+#if !UNITY_WEBGL
         // deallocate
         activeCallbacks.Remove( myID );
         // always set my callback to null
         myIntArrayCallback = null;
+#endif
     }
 
 
@@ -178,16 +182,38 @@ public class ChuckIntArraySyncer : MonoBehaviour
     }
 
     private CK_INT[] myIntArray = {};
+
+#if UNITY_WEBGL
+    [Serializable]
+    private class IntArrayJson
+    {
+        public CK_INT[] items;
+    }
+
+    private void MyCallback( string json )
+    {
+        if( string.IsNullOrEmpty( json ) )
+        {
+            myIntArray = new CK_INT[] {};
+            return;
+        }
+
+        IntArrayJson parsed = JsonUtility.FromJson<IntArrayJson>( json );
+        myIntArray = ( parsed != null && parsed.items != null ) ? parsed.items : new CK_INT[] {};
+    }
+#else
     private void MyCallback( CK_INT[] newArray )
     {
         myIntArray = newArray;
     }
+#endif
 
     void OnDestroy()
     {
         StopSyncing();
     }
 
+#if !UNITY_WEBGL
     #if AOT
     [AOT.MonoPInvokeCallback(typeof(Chuck.IntArrayCallbackWithID))]
     #endif
@@ -198,5 +224,6 @@ public class ChuckIntArraySyncer : MonoBehaviour
             activeCallbacks[id].MyCallback( newValue );
         }
     }
+#endif
     
 }


### PR DESCRIPTION
WebGL builds failed or behaved incorrectly when fetching or syncing ChucK global int/float arrays. 
The several array-related plugin exports were missing or wired incorrectly.

## Changes

### WebGL array get API
- Add `GetIntArray` / `GetFloatArray` overloads that take `(variableName, gameObjectName, methodName)` on `Chuck`, `ChuckMainInstance`, and `ChuckSubInstance`.
- Fix the broken WebGL `GetFloatArray` function.

### `AudioPluginChuck.jslib`
- Implement `getGlobalIntArrayWithUnityStyleCallback` / `getGlobalFloatArrayWithUnityStyleCallback`, delivering arrays as JSON (`{"items":[...]}`) via `SendMessage`.
- Add missing Named / WithID / `_AT` exports referenced by C# `DllImport`s so WebGL linking succeeds.
- Replace deprecated `Pointer_stringify` with `UTF8ToString` for newer Unity compatibility.

### Syncers and examples
- `ChuckFloatArraySyncer` / `ChuckIntArraySyncer`: on WebGL, parse the JSON `SendMessage` payload into managed arrays while keeping the same public syncer API.
- `ChunityExampleGlobalFloatArray` / `ChunityExampleGlobalIntArray`: use WebGL Unity-style get APIs and instance methods suitable for `SendMessage`.