### PR TITLE
Add Assembly Definitions for Runtime and Editor scripts

### DIFF
--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Chunity.Runtime.asmdef
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Chunity.Runtime.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Chunity.Runtime",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.UI"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Chunity.Runtime.asmdef.meta
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Chunity.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a36de0c086428a44287fba30136edfbf
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Editor/Chunity.Editor.asmdef
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Editor/Chunity.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Chunity.Editor",
+    "rootNamespace": "",
+    "references": [
+        "Chunity.Runtime"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/Editor/Chunity.Editor.asmdef.meta
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/Editor/Chunity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d083bbcc3554a2b47971358556005d9f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds Unity Assembly Definition (`.asmdef`) files so Chunity C# scripts compile into named assemblies instead of the default `Assembly-CSharp`.

This makes Chunity usable from other packages/plugins that use their own asmdefs (those assemblies cannot reference `Assembly-CSharp`).
It also keeps Editor-only code out of player builds.