### PR TITLE
Expose hooks for external audio drivers

### DIFF
--- a/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckMainInstance.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckMainInstance.cs
@@ -1105,6 +1105,26 @@ public class ChuckMainInstance : MonoBehaviour
         return hasInit;
     }
 
+    // ----------------------------------------------------
+    // name: GetMicClip
+    // desc: AudioClip started by SetupMic(), or null when
+    //       the microphone is unused / unavailable.
+    // ----------------------------------------------------
+    public AudioClip GetMicClip()
+    {
+        return micClip;
+    }
+
+    // ----------------------------------------------------
+    // name: GetMicDevice
+    // desc: device name passed to Microphone.Start /
+    //       GetPosition (empty string = default device).
+    // ----------------------------------------------------
+    public string GetMicDevice()
+    {
+        return myMicDevice;
+    }
+
     private void SetupMic()
     {
         // default device

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckMainInstance.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckMainInstance.cs
@@ -74,6 +74,17 @@ public class ChuckMainInstance : MonoBehaviour
     private bool clearChuckOnSceneLoad = false;
 
 
+    // ----------------------------------------------------
+    // name: useBuiltInAudioFilter
+    // desc: when true (default), OnAudioFilterRead advances
+    //       this VM. Set false when an external audio driver
+    //       (e.g. Unity Scriptable Audio Generator) owns the
+    //       ManualAudioCallback so FilterRead does not run
+    //       a second time.
+    // ----------------------------------------------------
+    [Tooltip( "Whether OnAudioFilterRead drives this ChucK VM. Set false when an external audio driver advances the VM instead." )]
+    public bool useBuiltInAudioFilter = true;
+
 
 
     // ----------------------------------------------------
@@ -1165,6 +1176,11 @@ public class ChuckMainInstance : MonoBehaviour
     #else
     void OnAudioFilterRead( float[] data, int channels )
     {
+        if( !useBuiltInAudioFilter )
+        {
+            return;
+        }
+
         // check whether channels is correct | added buffer length check (v2.2.0) eito
         if( channels != myNumChannels || data.Length != myOutBuffer.Length )
         {

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckSubInstance.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckSubInstance.cs
@@ -25,6 +25,17 @@ public class ChuckSubInstance : MonoBehaviour
 
 
     // ----------------------------------------------------
+    // name: useBuiltInAudioFilter
+    // desc: when true (default), OnAudioFilterRead pulls
+    //       this Sub's replacement-DAC UGen. Set false when
+    //       an external audio driver reads the UGen instead.
+    // ----------------------------------------------------
+    [Tooltip( "Whether OnAudioFilterRead drives this Sub. Set false when an external audio driver reads OutputUgen instead." )]
+    public bool useBuiltInAudioFilter = true;
+
+
+
+    // ----------------------------------------------------
     // name: chuckMainInstance
     // desc: ChuckSubInstance relies on a ChuckMainInstance
     //       that it shares with all other ChuckSubInstances
@@ -1176,6 +1187,11 @@ public class ChuckSubInstance : MonoBehaviour
     #else
     void OnAudioFilterRead( float[] data, int channels )
     {
+        if( !useBuiltInAudioFilter )
+        {
+            return;
+        }
+
         if( !chuckMainInstance.HasInit() )
         {
             // my chuck is not ready. be silent.

--- a/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckSubInstance.cs
+++ b/Chunity Boilerplate/Assets/Chunity/Scripts/ChuckSubInstance.cs
@@ -1229,6 +1229,28 @@ public class ChuckSubInstance : MonoBehaviour
     #endif
 
 
+    // ----------------------------------------------------
+    // name: OutputUgen
+    // desc: global UGen name used as this Sub's replacement
+    //       DAC (e.g. __dac__N). External drivers can pass
+    //       this to GetUGenSamples.
+    // ----------------------------------------------------
+    public string OutputUgen
+    {
+        get { return myOutputUgen; }
+    }
+
+    // ----------------------------------------------------
+    // name: IsRunning
+    // desc: true after Awake finishes Sub setup; false after
+    //       teardown. Matches the running gate used by
+    //       OnAudioFilterRead.
+    // ----------------------------------------------------
+    public bool IsRunning
+    {
+        get { return running; }
+    }
+
     public string GetUniqueVariableName()
     {
         return chuckMainInstance.GetUniqueVariableName();


### PR DESCRIPTION
## Summary

### Fix double audio callback 53efa8ff000d86fecdf7cb2c144e694525cde93a
- Add `useBuiltInAudioFilter` on `ChuckMainInstance` / `ChuckSubInstance` so callers can disable `OnAudioFilterRead` when another path advances the shared VM (avoids double `ManualAudioCallback` / double UGen reads).
  - The default behavior around `OnAudioFilterRead` is unchanged.

### Add Read-only accessors for some private fields
- Expose Main mic state via `GetMicClip()` / `GetMicDevice()`. fb48ab5d6cdde064d0fc22d01d079f32b21f9125
- Expose Sub replacement-DAC name and running status via `OutputUgen` / `IsRunning`. bc488bf7d45b25d49f58b7de3c95dab292969ca4

## Motivation

Integrations such as Unity 6 Scriptable Audio Generators need to drive ChucK from outside `OnAudioFilterRead`. Currently, the required state is private, so consumers must use reflection.
